### PR TITLE
Add a Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ dmypy.json
 
 # VSCode cruft
 .vscode
+
+# Nix build result
+result/
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742738698,
+        "narHash": "sha256-KCtAXWwQs03JmEhP4ss59QVzT+rHZkhQO85KjNy8Crc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f3a2a0601e9669a6e38af25b46ce6c4563bcb6da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,116 @@
+{
+  description = "Development environment for wallabag-client";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        version = "1.8.6";
+
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python312;
+        
+        # Define runtime dependencies
+        pythonRuntimeDeps = ps: with ps; [
+          beautifulsoup4
+          pycryptodome
+          requests
+          click
+          yaspin
+          click-repl
+          pyxdg
+          colorama
+          delorean
+          humanize
+          lxml
+          tzlocal
+          tabulate
+          packaging
+          markdownify
+        ];
+        
+        # Define development dependencies
+        pythonDevDeps = ps: with ps; [
+          pip
+          setuptools
+          setuptools-scm
+          wheel
+          pytest
+          black
+          flake8
+          mypy
+        ];
+        
+        # Full development environment
+        pythonEnv = python.withPackages (ps: 
+          pythonRuntimeDeps ps ++ pythonDevDeps ps
+        );
+        
+        # Define the package
+        wallabagClient = python.pkgs.buildPythonPackage {
+          pname = "wallabag-client";
+          version = version;
+          format = "setuptools";
+          
+          src = ./.;
+
+          nativeBuildInputs = with python.pkgs; [
+            pip
+            wheel
+            setuptools
+            setuptools-scm
+          ];
+          
+          propagatedBuildInputs = pythonRuntimeDeps python.pkgs;
+          
+          checkInputs = with python.pkgs; [
+            pytest
+          ];
+          
+          postPatch = ''
+            export SETUPTOOLS_SCM_PRETEND_VERSION=${version}
+            sed -i '/setup_requires=\[/,/]/d' setup.py
+          '';
+
+          meta = with pkgs.lib; {
+            description = "A command-line client for the self-hosted read-it-later app Wallabag";
+            homepage = "https://github.com/artur-shaik/wallabag-client";
+            license = licenses.mit;
+            maintainers = [];
+          };
+        };
+      in
+      {
+        packages = {
+          default = wallabagClient;
+          wallabag-client = wallabagClient;
+        };
+        
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pythonEnv
+            pkgs.pre-commit
+          ];
+
+          shellHook = ''
+            echo "wallabag-client development environment activated!"
+            echo "Python version: $(python --version)"
+            
+            # Make the package installable in development mode
+            export PYTHONPATH="$PWD/src:$PYTHONPATH"
+            
+            # Allow setup.py to work properly
+            export PIP_DISABLE_PIP_VERSION_CHECK=1
+            
+            # For setuptools_scm to work correctly
+            export SETUPTOOLS_SCM_PRETEND_VERSION=${version}
+          '';
+        };
+      }
+    );
+}
+


### PR DESCRIPTION
### Add a Nix flake

This PR adds a Nix flake with:

- A package derivation for `wallabag-client`, allowing Nix users to build and install it declaratively.
- A development shell, making it easier for contributors to work on the project with all dependencies preconfigured.

### Why?

- The flake is self-contained and will not interfere with non-Nix development or builds.
- The development shell ensures a reproducible dev environment without manual setup for those who want it.
- It simplifies packaging for downstream users and is a steps towards inclusion in nixpkgs.

### How to use

If you have Nix installed, you can:

```sh
# Enter the dev shell
nix develop

# Build the package
nix build
```

Once merged, Nix users can include `wallabag-client` in their flake-based configurations. For example:

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
    wallabag-client.url = "github:artur-shaik/wallabag-client";
  };
  outputs = { self, nixpkgs, wallabag-client, ... }: {
    nixosConfigurations.myMachine = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        ({ config, pkgs, ... }: {
          environment.systemPackages = [ wallabag-client.packages.${system}.default ];
        })
      ];
    };
  };
}
```