### PR TITLE
Add option to return internal URL to `add` command

### DIFF
--- a/completion/zsh/_wallabag
+++ b/completion/zsh/_wallabag
@@ -27,6 +27,7 @@ _wallabag() {
                         '(-r --read)'{-r,--read}'[Mark as read]' \
                         '(-s --starred)'{-s,--starred}'[Mark as starred]' \
                         '(-a --tags)'{-a,--tags}'[Comma-separated list of tags]:tags:_wallabag_tags' \
+                        '(-u --return-url)'{-u,--return-url}'[return the internal URL of the entry]' \
                         '(-q --quiet)'{-q,--quiet}'[Hide the output if no error occurs]' \
                         '(-h --help)'{-h,--help}'[Show this message and exit]' \
                         '*::URL: '

--- a/src/wallabag/api/api.py
+++ b/src/wallabag/api/api.py
@@ -82,6 +82,7 @@ class ApiMethod(Enum):
     DELETE_ANNOTATION = "/api/annotations/{0}"
     TOKEN = "/oauth/v2/token"
     VERSION = "/api/version"
+    VIEW = "/view/{0}"
 
 
 class Verbs(Enum):

--- a/src/wallabag/api/entry_exists.py
+++ b/src/wallabag/api/entry_exists.py
@@ -11,6 +11,7 @@ class EntryExists(Api):
 
     class ApiParams(Enum):
         URL = "url"
+        RETURN_ID = "return_id"
 
     def __init__(self, config, url):
         Api.__init__(self, config)
@@ -26,5 +27,6 @@ class EntryExists(Api):
         if not self.url:
             raise ValueException("URL is empty")
         return {
-            EntryExists.ApiParams.URL.value: self.url
+            EntryExists.ApiParams.URL.value: self.url,
+            EntryExists.ApiParams.RETURN_ID.value: 1,
         }

--- a/src/wallabag/commands/add.py
+++ b/src/wallabag/commands/add.py
@@ -2,7 +2,8 @@
 
 from colorama import Fore
 
-from wallabag.api.add_entry import AddEntry, Params as AddEntryParams
+from wallabag.api.add_entry import AddEntry, ApiMethod
+from wallabag.api.add_entry import Params as AddEntryParams
 from wallabag.api.entry_exists import EntryExists
 from wallabag.commands.command import Command
 from wallabag.commands.tags_param import TagsParam
@@ -16,14 +17,23 @@ class AddCommandParams(Params, TagsParam):
     starred = None
     read = None
     tags = None
+    return_url = None
 
-    def __init__(self, target_url, title=None,
-                 starred=None, read=None, tags=None):
+    def __init__(
+        self,
+        target_url,
+        title=None,
+        starred=None,
+        read=None,
+        tags=None,
+        return_url=None,
+    ):
         self.target_url = target_url
         self.title = title
         self.starred = starred
         self.read = read
         self.tags = tags
+        self.return_url = return_url
 
     def validate(self):
         return self._validate_tags()
@@ -39,7 +49,10 @@ class AddCommand(Command):
     def _run(self):
         params = self.params
         api = EntryExists(self.config, params.target_url)
-        if api.request().response['exists']:
+        response = api.request().response
+        if "exists" in response and response["exists"] is not None:
+            if self.params.return_url:
+                return True, api._build_url(ApiMethod.VIEW).format(response["exists"])
             return True, "The url was already saved."
 
         entry = Entry(AddEntry(self.config, params.target_url, {
@@ -48,6 +61,8 @@ class AddCommand(Command):
             AddEntryParams.STARRED: params.starred,
             AddEntryParams.TAGS: params.tags
         }).request().response)
+        if self.params.return_url:
+            return True, api._build_url(ApiMethod.VIEW).format(entry.entry_id)
         return True, (
                 "Entry successfully added:\n\n"
                 f"\t{Fore.GREEN}{entry.entry_id}. {entry.title}{Fore.RESET}\n")

--- a/src/wallabag/wallabag.py
+++ b/src/wallabag/wallabag.py
@@ -222,14 +222,16 @@ def star(ctx, entry_id, quiet):
 @click.option('-s', '--starred', default=False, is_flag=True,
               help="Mark as starred.")
 @click.option('-a', '--tags', help="Comma-separated list of tags")
+@click.option('-u', '--return-url', default=False, is_flag=True,
+              help='return the internal URL of the entry')
 @click.option('-q', '--quiet', default=False, is_flag=True,
               help="Hide the output if no error occurs.")
 @click.argument('url', required=True)
 @need_config
 @click.pass_context
-def add(ctx, url, title, read, starred, tags, quiet):
+def add(ctx, url, title, read, starred, tags, quiet, return_url):
     """Add a new entry to wallabag."""
-    params = AddCommandParams(url, title, starred, read, tags)
+    params = AddCommandParams(url, title, starred, read, tags, return_url)
     run_command(AddCommand(ctx.obj, params), quiet)
 
 


### PR DESCRIPTION
I added the `--return-url` option to the `add` command to facilitate further scripting based on this CLI. It works for both existing and new entries.