### PR TITLE
Allow for easier running from directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile.lock
 
 # celery beat schedule file
 celerybeat-schedule
@@ -126,6 +126,8 @@ dmypy.json
 # VSCode cruft
 .vscode
 
+# Zed
+.zed
+
 # Nix build result
 result/
-

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,30 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+beautifulsoup4 = "*"
+pycryptodome = "*"
+requests = "*"
+click = "*"
+yaspin = "*"
+click-repl = "*"
+pyxdg = "*"
+colorama = "*"
+delorean = "*"
+humanize = "*"
+lxml = "*"
+tzlocal = "*"
+tabulate = "*"
+packaging = "*"
+markdownify = "*"
+
+[dev-packages]
+pytest-runner = "*"
+setuptools-scm = "*"
+wheel = "*"
+pytest = "*"
+
+[requires]
+python_version = "3.13"

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import sys
+
+from wallabag.wallabag import cli
+
+if __name__ == "__main__":
+    sys.argv[0] = sys.argv[0].removesuffix(".exe")
+    sys.exit(cli())


### PR DESCRIPTION
Setting up a development environment was harder than it had to be. I added a `Pipfile` and `src/main.py` to make it easier to run the CLI directly from the directory (and therefore debugging it within my IDE).